### PR TITLE
fix(Login.tsx): make a material ui react button act as a react-router-dom link

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,8 +16,6 @@ const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleLogin = () => {};
-
   return (
     <>
       <Container maxWidth="xs">
@@ -62,14 +60,15 @@ const Login = () => {
             />
 
             <Button
+              component={Link}
               fullWidth
+              to="/home"
               variant="contained"
               sx={{ mt: 3, mb: 2 }}
-              href={process.env.PUBLIC_URL + "/home"}
-              onClick={handleLogin}
             >
               Login
             </Button>
+
             <Grid container justifyContent={"flex-end"}>
               <Grid item>
                 <Link to="/register">Don't have an account? Register</Link>

--- a/src/pages/LoginSuccess.tsx
+++ b/src/pages/LoginSuccess.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Typography,
 } from "@mui/material";
+import { Link } from "react-router-dom";
 
 const LoginSuccess = () => {
   return (
@@ -20,11 +21,13 @@ const LoginSuccess = () => {
             alignItems: "center",
           }}
         >
-            <Avatar sx={{ m: 1, bgcolor: "primary.light" }}>
-              <CheckCircle />
-            </Avatar>
-            <Typography variant="h5">LoginSuccess</Typography>
+          <Avatar sx={{ m: 1, bgcolor: "primary.light" }}>
+            <CheckCircle />
+          </Avatar>
+          <Typography variant="h5">LoginSuccess</Typography>
+          <Link to="/">
             <img src="https://scontent.ftpe7-4.fna.fbcdn.net/v/t1.18169-9/998025_10151520012340920_1273035109_n.jpg?_nc_cat=105&ccb=1-7&_nc_sid=f798df&_nc_ohc=_HN2ki-NJdwQ7kNvgFA9NKO&_nc_ht=scontent.ftpe7-4.fna&oh=00_AYATB7lOPZlc2v0mq6-2OMdFrSwCoL3zV_-IVmRF3kUUjg&oe=66B450BD" alt="Jersey" width="500" height="600"></img>
+          </Link>
         </Box>
       </Container >
     </>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -17,8 +17,6 @@ const Register = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleRegister = async () => { };
-
   return (
     <>
       <Container maxWidth="xs">
@@ -74,16 +72,17 @@ const Register = () => {
                 />
               </Grid>
             </Grid>
+
             <Button
+              component={Link}
               fullWidth
+              to="/home"
               variant="contained"
               sx={{ mt: 3, mb: 2 }}
-              href={process.env.PUBLIC_URL + "/home"}
-              data-test-locator = 'login'
-              onClick={handleRegister}
             >
               Register
             </Button>
+
             <Grid container justifyContent="flex-end">
               <Grid item>
                 <Link to="/login">Already have an account? Login</Link>


### PR DESCRIPTION
fix(Login.tsx): make a material ui react button act as a react-router-dom link

Before
![Screenshot 2024-07-09 at 8 28 09 PM](https://github.com/jerseysu/playwright-demo/assets/3646706/5d91a582-76e6-4e5f-b76f-2ec5af58ea68)



After
![Screenshot 2024-07-09 at 8 28 15 PM](https://github.com/jerseysu/playwright-demo/assets/3646706/aeb222cc-4998-4d0c-a4a1-5d7428d1d18d)


Reference:
https://stackoverflow.com/questions/51642532/how-to-make-a-material-ui-react-button-act-as-a-react-router-dom-link